### PR TITLE
Botón kazoo

### DIFF
--- a/components/AccionBotonKazoo.js
+++ b/components/AccionBotonKazoo.js
@@ -25,11 +25,6 @@ export const AccionBotonKazoo = ({ className, indice, clickeado, children, total
       .on.accion {
         transform: translate3d(${Math.cos((total - indice) * Math.PI / (total + 1)) * radio}px, -${Math.sin((total - indice) * Math.PI / (total + 1)) * radio}px, 0);
       }
-        
-      @keyframes slide-in {
-        from { transform: translateY(100%); }
-        to { transform: translateY(0); }
-      }
     `}</style>
-  </Fragment>
+  </Fragment>;
 

--- a/components/AccionBotonKazoo.js
+++ b/components/AccionBotonKazoo.js
@@ -1,0 +1,35 @@
+import { Fragment } from 'react';
+
+const radio = 70;
+
+export const AccionBotonKazoo = ({ className, indice, clickeado, children, total, ...props}) =>
+  <Fragment>
+    <div className={`accion accion-${indice} ${clickeado ? 'on' : ''} ${className || ''}`} { ...props }>{ children }</div>
+    <style jsx>{`
+      .accion {
+        display: flex;
+        position: absolute;
+        margin: auto;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        background-color: #5CDB94;
+        transition: transform 300ms ease-out;
+        z-index: -1;
+      }
+      
+      .on.accion {
+        transform: translate3d(${Math.cos((total - indice) * Math.PI / (total + 1)) * radio}px, -${Math.sin((total - indice) * Math.PI / (total + 1)) * radio}px, 0);
+      }
+        
+      @keyframes slide-in {
+        from { transform: translateY(100%); }
+        to { transform: translateY(0); }
+      }
+    `}</style>
+  </Fragment>
+

--- a/components/AccionBotonKazoo.js
+++ b/components/AccionBotonKazoo.js
@@ -14,15 +14,19 @@ export const AccionBotonKazoo = ({ className, indice, clickeado, children, total
         left: 0;
         bottom: 0;
         right: 0;
-        width: 30px;
-        height: 30px;
+        width: 0;
+        height: 0;
         border-radius: 50%;
         background-color: #5CDB94;
-        transition: transform 300ms ease-out;
+        transition: transform 300ms ease-out, opacity 300ms ease-out, height 300ms ease-out, width 300ms ease-out;
         z-index: -1;
+        opacity: 0;
       }
       
       .on.accion {
+        width: 30px;
+        height: 30px;
+        opacity: 1;
         transform: translate3d(${Math.cos((total - indice) * Math.PI / (total + 1)) * radio}px, -${Math.sin((total - indice) * Math.PI / (total + 1)) * radio}px, 0);
       }
     `}</style>

--- a/components/BotonKazoo.js
+++ b/components/BotonKazoo.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+
+const radio = 50;
+
+export class BotonKazoo extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { clickeado: false };
+  }
+
+  alternarEstado() {
+    this.setState({ clickeado: !this.state.clickeado });
+  }
+
+  render() {
+    return <div id="kazoo">
+      <button id="boton" onClick={this.alternarEstado.bind(this)}>
+        <div className={this.state.clickeado ? 'accion-1': ''} />
+        <div className={this.state.clickeado ? 'accion-2': ''} />
+        <div className={this.state.clickeado ? 'accion-3': ''} />
+      </button>
+      <style jsx>{`
+      #kazoo {
+        display: flex;
+        position: relative;
+        justify-content: center;
+        height: 25px;
+        background-color: #5CDB94;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        animation: slide-in 1s;
+      }
+      
+      #boton {
+        position: relative;
+        border-radius: 50%;
+        border: 0;
+        top: -25px;
+        width: 50px;
+        height: 50px;
+        background-image: url(/static/img/kazoo-icon.svg);
+        transform: scale(1.3)
+      }
+      
+      #boton > div {
+        position: absolute;
+        margin:auto;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background-color: #5CDB94;
+        transition: transform 300ms ease-out;
+      }
+      
+      .accion-1 {
+        transform: translate3d(${Math.cos(3 * Math.PI / 4) * radio}px, -${Math.sin(3 * Math.PI / 4) * radio}px, 0);
+      }
+      
+      .accion-2 {
+        transform: translate3d(${Math.cos(2 * Math.PI / 4) * radio}px, -${Math.sin(2 * Math.PI / 4) * radio}px, 0);
+      }
+      
+      .accion-3 {
+        transform: translate3d(${Math.cos(Math.PI / 4) * radio}px, -${Math.sin(Math.PI / 4) * radio}px, 0);
+      }
+        
+      @keyframes slide-in {
+        from { transform: translateY(100%); }
+        to { transform: translateY(0); }
+      }
+    `}</style>
+    </div>;
+  }
+}

--- a/components/BotonKazoo.js
+++ b/components/BotonKazoo.js
@@ -27,7 +27,6 @@ export class BotonKazoo extends Component {
       <style jsx>{`
       #kazoo {
         display: flex;
-        position: relative;
         justify-content: center;
         height: 36px;
         background-color: #5CDB94;
@@ -48,6 +47,11 @@ export class BotonKazoo extends Component {
         background-color: white;
         background-image: url(/static/img/kazoo-icon.svg);
         transform: scale(1.3);
+        outline: none;
+      }
+      
+      #boton::-moz-focus-inner {
+        border: none;
       }
       
       #icon {
@@ -61,6 +65,11 @@ export class BotonKazoo extends Component {
         right: 0;
         background-color: #5CDB94;
         border-radius: 50%;
+      }
+      
+      @keyframes slide-in {
+        from { transform: translateY(100%); }
+        to { transform: translateY(0); }
       }
     `}</style>
     </div>;

--- a/components/BotonKazoo.js
+++ b/components/BotonKazoo.js
@@ -38,6 +38,9 @@ export class BotonKazoo extends Component {
       }
       
       #boton {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         position: relative;
         border-radius: 50%;
         border: none;
@@ -54,17 +57,9 @@ export class BotonKazoo extends Component {
         border: none;
       }
       
-      #icon {
-        width: 20px;
-        height: 20px;
-        position: absolute;
-        margin: auto;
-        top: -3px;
-        left: -3px;
-        bottom: 0;
-        right: 0;
-        background-color: #5CDB94;
-        border-radius: 50%;
+      #icon {        
+        width: 25px;
+        height: 25px;
       }
       
       @keyframes slide-in {

--- a/components/BotonKazoo.js
+++ b/components/BotonKazoo.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-
-const radio = 50;
+import Icon from '@material-ui/core/Icon';
 
 export class BotonKazoo extends Component {
   constructor(props) {
@@ -12,19 +11,25 @@ export class BotonKazoo extends Component {
     this.setState({ clickeado: !this.state.clickeado });
   }
 
+  renderizarAcciones() {
+    return React.Children.map(this.props.children, (accion, indice) =>
+      React.cloneElement(accion, { clickeado: this.state.clickeado, indice: indice, total: this.props.children.length || 1}))
+  }
+
   render() {
     return <div id="kazoo">
-      <button id="boton" onClick={this.alternarEstado.bind(this)}>
-        <div className={this.state.clickeado ? 'accion-1': ''} />
-        <div className={this.state.clickeado ? 'accion-2': ''} />
-        <div className={this.state.clickeado ? 'accion-3': ''} />
+      <button id="boton" onClick={ this.props.onClick || this.alternarEstado.bind(this)}>
+        <span id="icon">
+          <Icon>{ this.state.clickeado ? 'clear' : this.props.icono }</Icon>
+        </span>
+        { this.renderizarAcciones() }
       </button>
       <style jsx>{`
       #kazoo {
         display: flex;
         position: relative;
         justify-content: center;
-        height: 25px;
+        height: 36px;
         background-color: #5CDB94;
         position: fixed;
         bottom: 0;
@@ -36,43 +41,26 @@ export class BotonKazoo extends Component {
       #boton {
         position: relative;
         border-radius: 50%;
-        border: 0;
-        top: -25px;
-        width: 50px;
-        height: 50px;
+        border: none;
+        top: -40px;
+        width: 75px;
+        height: 75px;
+        background-color: white;
         background-image: url(/static/img/kazoo-icon.svg);
-        transform: scale(1.3)
+        transform: scale(1.3);
       }
       
-      #boton > div {
-        position: absolute;
-        margin:auto;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
+      #icon {
         width: 20px;
         height: 20px;
-        border-radius: 50%;
+        position: absolute;
+        margin: auto;
+        top: -3px;
+        left: -3px;
+        bottom: 0;
+        right: 0;
         background-color: #5CDB94;
-        transition: transform 300ms ease-out;
-      }
-      
-      .accion-1 {
-        transform: translate3d(${Math.cos(3 * Math.PI / 4) * radio}px, -${Math.sin(3 * Math.PI / 4) * radio}px, 0);
-      }
-      
-      .accion-2 {
-        transform: translate3d(${Math.cos(2 * Math.PI / 4) * radio}px, -${Math.sin(2 * Math.PI / 4) * radio}px, 0);
-      }
-      
-      .accion-3 {
-        transform: translate3d(${Math.cos(Math.PI / 4) * radio}px, -${Math.sin(Math.PI / 4) * radio}px, 0);
-      }
-        
-      @keyframes slide-in {
-        from { transform: translateY(100%); }
-        to { transform: translateY(0); }
+        border-radius: 50%;
       }
     `}</style>
     </div>;

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic';
 import Nota from '../components/Nota';
 import { MarcadorDeTempo } from '../components/MarcadorDeTempo';
 import React from 'react';
+import { BotonKazoo } from '../components/BotonKazoo';
 
 const Partitura = dynamic(() => import('../components/Partitura'), { ssr: false });
 const Compas = dynamic(() => import('../components/Compas'), { ssr: false });
@@ -35,6 +36,7 @@ export default class Home extends React.Component {
           </Partitura>
         </div>
         <MarcadorDeTempo anteNuevoCompas={this.alRecibirCompas.bind(this)}/>
+        <BotonKazoo/>
         <style jsx>{`
       #contenedor {
         height: 100%;

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,6 @@ import dynamic from 'next/dynamic';
 import Nota from '../components/Nota';
 import { MarcadorDeTempo } from '../components/MarcadorDeTempo';
 import React from 'react';
-import { BotonKazoo } from '../components/BotonKazoo';
 
 const Partitura = dynamic(() => import('../components/Partitura'), { ssr: false });
 const Compas = dynamic(() => import('../components/Compas'), { ssr: false });
@@ -36,7 +35,6 @@ export default class Home extends React.Component {
           </Partitura>
         </div>
         <MarcadorDeTempo anteNuevoCompas={this.alRecibirCompas.bind(this)}/>
-        <BotonKazoo/>
         <style jsx>{`
       #contenedor {
         height: 100%;


### PR DESCRIPTION
La idea es que sea un botón contextual, que pueda hacer/mostrar distintas cosas según la página en la que esté. Es un botón redondo, anclado al footer de la página y con el logo de Kazoo en el centro. El botón soporta que se le pase una prop de `onClick` para ejecutar un callback o, si no se le pasa nada, va a desplegar las posibles acciones que pueden hacerse en esa página determinada:

![boton2](https://user-images.githubusercontent.com/7256526/64915900-f1269c00-d747-11e9-9c47-9ba21b12f583.gif)


Una cosa a destacar es que las acciones quedan espaciadas entre sí equitativamente en la semicircunferencia superiror del logo, no importa la cantidad que sean (aunque, obviamente, se van a empezar a apelotonar cuando sean muchas):

![boton1](https://user-images.githubusercontent.com/7256526/64915901-f683e680-d747-11e9-945a-6065cd512f2d.gif)
![boton5](https://user-images.githubusercontent.com/7256526/64915902-f683e680-d747-11e9-836b-6b5ede15addb.gif)


Cada acción (reificada con el componente `AccionBotonKazoo` puede mostrar dentro de sí cualquier cosa que se le pase por `children` y se le puede pasar un callback en un `onClick` (notar que el callback también cierra las acciones.

La idea es que en estas acciones se implementen los botones de edición, como cambiar el metro, la tonalidad, etc