### PR TITLE
Agregar soporte para enlaces entre corcheas y semis

### DIFF
--- a/model/Notas.js
+++ b/model/Notas.js
@@ -1,0 +1,7 @@
+export const esCorchea = nota => nota.duration === '8'
+
+export const esSemi = nota => nota.duration === '16'
+
+export const esSilencio = nota => nota.pitch === 'r'
+
+export const esEnlazable = nota => esCorchea(nota) || esSemi(nota)


### PR DESCRIPTION
Lo agrego al final del loop que procesa las notas que llegan del servicio de detección.

![enlaces](https://user-images.githubusercontent.com/7256526/66620929-ad914780-ebb8-11e9-9770-7382bfe6b123.png)
