### PR TITLE
Gran refactor de la página de partitura

### DIFF
--- a/components/Partitura.js
+++ b/components/Partitura.js
@@ -1,121 +1,24 @@
-import { debounce, last, isEmpty } from 'lodash'
-import { memo, useEffect, useRef, useState } from 'react'
-import { Accidental } from 'vexflow/src/accidental'
-import { Formatter } from 'vexflow/src/formatter'
-import { Renderer } from 'vexflow/src/renderer'
-import { Stave } from 'vexflow/src/stave'
-import { StaveNote } from 'vexflow/src/stavenote'
-import { StaveTie } from 'vexflow/src/stavetie'
-import { Vex } from 'vexflow/src/vex'
-import { Voice } from 'vexflow/src/voice'
-import { Beam } from 'vexflow/src/beam';
-import { useTamanioVentana } from '../hooks/useTamanioVentana'
-import { esCorchea, esEnlazable, esSemi, esSilencio } from '../model/Notas';
+import { memo, useRef } from 'react'
+import { useScrollAutomatico } from '../hooks/useScrollAutomatico'
+import { useNotasVexflow } from '../hooks/useNotasVexflow'
+import { useNotasClickHandlers } from '../hooks/useNotasClickHandler'
+import { useVexRenderer } from '../hooks/useVexRenderer'
 
-export default memo(function Partitura({
-  nombre, tonalidad, metro, compases, scrollea, onClickNota = () => { }
-}) {
+export default memo(function Partitura({nombre, tonalidad, metro, compases, scrollea, onClickNota = () => {}}) {
   const contenedorRef = useRef()
   const lienzoRef = useRef()
-  const rendererRef = useRef()
-  const [estaAlFinal, setEstaAlFinal] = useState(true)
-  useEffect(() => {
-    rendererRef.current = new Renderer(lienzoRef.current, Renderer.Backends.SVG)
-    const cuandoScrolea = debounce(e => {
-      setEstaAlFinal(e.target.scrollTop + e.target.offsetHeight === e.target.scrollHeight)
-    }, 35)
-    contenedorRef.current.addEventListener('scroll', cuandoScrolea)
-    return contenedorRef.current.removeEventListener('scroll', cuandoScrolea)
-  }, [])
   const finDelLienzoRef = useRef()
-  const tamanioVentana = useTamanioVentana()
-  useEffect(() => {
-    const anchoLienzo = lienzoRef.current.offsetWidth
-    const alturaLienzo = compases.length * 100 + 200
-    lienzoRef.current.style.height = alturaLienzo + 'px'
-    if (scrollea && estaAlFinal) {
-      finDelLienzoRef.current.scrollIntoView({ behavior: 'smooth' })
-    }
-    rendererRef.current.resize(anchoLienzo, alturaLienzo)
-    const contexto = rendererRef.current.getContext()
-    contexto.clear()
-    contexto.setFont('Roboto', 25, 'italic bold')
-    contexto.fillText(nombre, '50%', 50)
-    const espacioDibujable = anchoLienzo - 23
-    compases.map((notasDelCompas, i) => {
-      const [x, y] = [0, i * 100 + 50]
-      const compas = new Stave(x, y, espacioDibujable)
-        .addClef('treble')
-        .addKeySignature(tonalidad)
-        .addTimeSignature(`${metro.numerador}/${metro.denominador}`)
-        .setContext(contexto)
-        .draw()
-      const notas = []
-      const ligaduras = []
-      const notasClickHandlersMap = new Map()
-      const enlaces = []
-      let enlaceActual = []
-      let notaAnterior = { duration: '' }
-      notasDelCompas.forEach(nota => {
-        const notaClickHandler = () => onClickNota({ compas: notasDelCompas, nota })
-        const altura = nota.pitch === 'r' ? 'g/4' : nota.pitch
-        const agregarNota = duracion => {
-          const notaVexflow = new StaveNote({
-            keys: [altura],
-            duration: nota.pitch === 'r' ? duracion + 'r' : duracion,
-          })
-          notas.push(notaVexflow)
-          notasClickHandlersMap.set(Vex.Prefix(notaVexflow.attrs.id), notaClickHandler)
-          return notaVexflow
-        }
-        if (nota.has_tie) {
-          const [primeraDuracion, segundaDuracion] = nota.duration
-          ligaduras.push(new StaveTie({
-            first_note: agregarNota(primeraDuracion), first_indices: [0],
-            last_note: agregarNota(segundaDuracion), last_indices: [0]
-          }))
-        } else {
-          agregarNota(nota.duration)
-        }
-
-        if (!esSilencio(nota) && ([nota, notaAnterior].every(esCorchea) || [nota, notaAnterior].every(esSemi))) {
-          enlaceActual.push(last(notas))
-        } else if (isEmpty(enlaceActual) && esEnlazable(nota)) {
-          enlaceActual.push(last(notas))
-        } else if (enlaceActual.length > 1  && esEnlazable(nota)) {
-          enlaces.push(new Beam(enlaceActual))
-          enlaceActual = [last(notas)]
-        } else {
-          enlaceActual = []
-        }
-        notaAnterior = nota
-      })
-      const melodia = new Voice({
-        num_beats: metro.numerador,
-        beat_value: metro.denominador,
-      }).addTickables(notas)
-      Accidental.applyAccidentals([melodia], tonalidad)
-      new Formatter()
-        .joinVoices([melodia])
-        .format([melodia], espacioDibujable)
-      melodia.draw(contexto, compas)
-      ligaduras.forEach(ligadura => ligadura.setContext(contexto).draw())
-      enlaces.forEach(enlace => enlace.setContext(contexto).draw())
-      const notesDibujadas = [...document.getElementsByClassName('vf-stavenote')]
-      notesDibujadas.forEach(
-        n => n.addEventListener('click', notasClickHandlersMap.get(n.id))
-      )
-      return () => notesDibujadas.forEach(
-        n => n.removeEventListener('click', notasClickHandlersMap.get(n.id))
-      )
-    })
-  }, [tonalidad, metro, compases, tamanioVentana])
+  const alturaLienzo = compases.length * 100 + 200
+  const renderer = useVexRenderer(lienzoRef)
+  useScrollAutomatico(alturaLienzo, lienzoRef, scrollea, finDelLienzoRef, contenedorRef)
+  const [_, clickHandlers] = useNotasVexflow(renderer, lienzoRef, compases, nombre, tonalidad, metro, onClickNota)
+  useNotasClickHandlers(clickHandlers)
   return (
     <div id="contenedor" ref={contenedorRef}>
       <div id="partitura">
-        <div id="lienzo" ref={lienzoRef}></div>
+        <div id="lienzo" ref={lienzoRef}/>
       </div>
-      <div ref={finDelLienzoRef} />
+      <div ref={finDelLienzoRef}/>
       <style jsx global>{`
         text {
           text-transform: uppercase;

--- a/hooks/useNotasClickHandler.js
+++ b/hooks/useNotasClickHandler.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+export const useNotasClickHandlers = notasClickHandlers => {
+  useEffect(() => {
+    const notasDibujadas = [...document.getElementsByClassName('vf-stavenote')]
+
+    notasDibujadas.forEach(
+      n => n.addEventListener('click', notasClickHandlers.get(n.id))
+    )
+
+    return () => notasDibujadas.forEach(
+      n => n.removeEventListener('click', notasClickHandlers.get(n.id))
+    )
+  })
+}

--- a/hooks/useNotasVexflow.js
+++ b/hooks/useNotasVexflow.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { Accidental } from 'vexflow/src/accidental'
+import { Formatter } from 'vexflow/src/formatter'
+import { compasAVexflow, calcularEnlaces, melodiaAVexflow, notasAVexflow } from '../model/AdaptadorVexflow'
+import { useTamanioVentana } from './useTamanioVentana'
+
+const dibujarTodo = (contexto, anchoDibujable, melodia, tonalidad, compas, ligaduras, enlaces) => {
+  Accidental.applyAccidentals([melodia], tonalidad)
+  new Formatter()
+    .joinVoices([melodia])
+    .format([melodia], anchoDibujable)
+  melodia.draw(contexto, compas)
+  ligaduras.forEach(ligadura => ligadura.setContext(contexto).draw())
+  compas.setContext(contexto).draw()
+  enlaces.forEach(enlace => enlace.setContext(contexto).draw())
+}
+
+const obtenerContexto = (renderer, nombre) => {
+  const contexto = renderer.getContext()
+  contexto.clear()
+  contexto.setFont('Roboto', 25, 'italic bold')
+  contexto.fillText(nombre, '50%', 50)
+  return contexto
+}
+
+const obtenerAnchoDibujable = (lienzoRef, compases, renderer) => {
+  const anchoLienzo = lienzoRef.current.offsetWidth
+  const alturaLienzo = compases.length * 100 + 200
+  renderer.resize(anchoLienzo, alturaLienzo)
+  return anchoLienzo - 23
+}
+
+export const useNotasVexflow = (renderer, lienzoRef, compases, nombre, tonalidad, metro, onClickNota) => {
+  const tamanioVentana = useTamanioVentana()
+  const notasClickHandlers = new Map()
+  let notasTraducidas = []
+  const [notasVexflow, setNotasVexflow] = useState([])
+  useEffect(() => {
+    if (renderer) {
+      const anchoDibujable = obtenerAnchoDibujable(lienzoRef, compases, renderer)
+      const contexto = obtenerContexto(renderer, nombre)
+      compases.forEach((notasDelCompas, numeroDeCompas) => {
+        const [notas, ligaduras] = notasAVexflow(notasDelCompas, notasClickHandlers, onClickNota)
+        const enlaces = calcularEnlaces(notas)
+        const melodia = melodiaAVexflow(metro, notas)
+        const compas = compasAVexflow(numeroDeCompas * 100 + 50, anchoDibujable, tonalidad, metro)
+        dibujarTodo(contexto, anchoDibujable, melodia, tonalidad, compas, ligaduras, enlaces)
+        notasTraducidas = [...notasTraducidas, ...notas]
+      })
+      setNotasVexflow(notasTraducidas)
+    }
+  }, [tonalidad, metro, compases, tamanioVentana])
+  return [notasVexflow, notasClickHandlers]
+}

--- a/hooks/useScrollAutomatico.js
+++ b/hooks/useScrollAutomatico.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+import { debounce } from 'lodash'
+
+export const useScrollAutomatico = (alturaLienzo, lienzoRef, scrollea, finDelLienzoRef, contenedorRef) => {
+  const [estaAlFinal, setEstaAlFinal] = useState(true)
+  useEffect(() => {
+    lienzoRef.current.style.height = alturaLienzo + 'px'
+    if (scrollea && estaAlFinal) {
+      finDelLienzoRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
+    const cuandoScrollea = debounce(e => {
+      setEstaAlFinal(e.target.scrollTop + e.target.offsetHeight === e.target.scrollHeight)
+    }, 35)
+    contenedorRef.current.addEventListener('scroll', cuandoScrollea)
+    return contenedorRef.current.removeEventListener('scroll', cuandoScrollea)
+  })
+}

--- a/hooks/useVexRenderer.js
+++ b/hooks/useVexRenderer.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+import { Renderer } from 'vexflow/src/renderer'
+
+export const useVexRenderer = (lienzoRef) => {
+  const [renderer, setRenderer] = useState()
+
+  useEffect(() => {
+    setRenderer(new Renderer(lienzoRef.current, Renderer.Backends.SVG))
+  }, [])
+
+  return renderer
+}

--- a/model/AdaptadorVexflow.js
+++ b/model/AdaptadorVexflow.js
@@ -1,0 +1,78 @@
+import { StaveNote } from 'vexflow/src/stavenote'
+import { StaveTie } from 'vexflow/src/stavetie'
+import { Stave } from 'vexflow/src/stave'
+import { Voice } from 'vexflow/src/voice'
+import { Vex } from 'vexflow/src/vex'
+import { esCorchea, esEnlazable, esSemi, esSilencio } from './Notas'
+import { isEmpty } from 'lodash'
+import { Beam } from 'vexflow/src/beam'
+
+const notaAVexflow = (nota, duracion) => new StaveNote({
+  keys: [nota.pitch === 'r' ? 'g/4' : nota.pitch],
+  duration: nota.pitch === 'r' ? duracion + 'r' : duracion,
+});
+
+const pasarAVexflow = nota => {
+  let ligadura;
+  let notasGeneradas;
+
+  if (nota.has_tie) {
+    const [primeraNotaVexflow, segundaNotaVexflow] = nota.duration.map(duracion => notaAVexflow(nota, duracion));
+    ligadura = new StaveTie({
+      first_note: primeraNotaVexflow, first_indices: [0],
+      last_note: segundaNotaVexflow, last_indices: [0]
+    });
+    notasGeneradas = [primeraNotaVexflow, segundaNotaVexflow];
+  } else {
+    notasGeneradas = [notaAVexflow(nota, nota.duration)];
+  }
+
+  return [notasGeneradas, ligadura];
+};
+
+export const notasAVexflow = (notasDelCompas, clickHandlers, callbackNotaClickeada) => {
+  return notasDelCompas.reduce(([notas, ligaduras], nota) => {
+    const [notasGeneradas, ligadurasNuevas] = pasarAVexflow(nota);
+    notas.push(...notasGeneradas);
+    if (ligadurasNuevas) {
+      ligaduras.push(ligadurasNuevas);
+    }
+    notasGeneradas.forEach(nota => clickHandlers.set(Vex.Prefix(nota.attrs.id), () => callbackNotaClickeada({
+      compas: notasDelCompas,
+      nota
+    })))
+    return [notas, ligaduras]
+  }, [[], []])
+};
+
+export const compasAVexflow = (posicionEnY, ancho, tonalidad, metro) => (
+  new Stave(0, posicionEnY, ancho)
+    .addClef('treble')
+    .addKeySignature(tonalidad)
+    .addTimeSignature(`${metro.numerador}/${metro.denominador}`)
+);
+
+export const melodiaAVexflow = (metro, notas) => (
+  new Voice({
+    num_beats: metro.numerador,
+    beat_value: metro.denominador,
+  }).addTickables(notas)
+);
+
+export const calcularEnlaces = (notas) => {
+  return notas.reduce(([notaAnterior, enlaces, enlaceActual], nota) => {
+    if (!esSilencio(nota) && ([nota, notaAnterior].every(esCorchea) || [nota, notaAnterior].every(esSemi))) {
+      enlaceActual.push(nota)
+    } else if (isEmpty(enlaceActual) && esEnlazable(nota)) {
+      enlaceActual.push(nota)
+    } else if (enlaceActual.length > 1 && esEnlazable(nota)) {
+      enlaces.push(new Beam(enlaceActual))
+      enlaceActual = [nota]
+    } else if (enlaceActual.length > 1 && !esEnlazable(nota)) {
+      enlaces.push(new Beam(enlaceActual))
+    } else {
+      enlaceActual = []
+    }
+    return [nota, enlaces, enlaceActual]
+  }, [{duration: ''}, [], []])[1]
+}


### PR DESCRIPTION
¿Cuál es el fin máximo de todo esto? Poder implementar más fácil la
reproducción de una partitura (e incluso cambiar la duración de una nota
dentro de un compás).
Lo más importante es que se parte en varios pedazos la lógica que no
era de renderizado que estaba en el fuente `partitura.js`. El rationale
de eso fue:
* Sacar todo lo que sea un efecto de lado a un `Effect`
* Separar responsabilidades en distintos `Effects` así no queda uno
  sólo muy complejo (este es el caso de separar la creación de handlers
  para los clicks, que es ortogonal al hecho de dibujar las cosas con
  vexflow)
* Tratar de aislar los puntos donde dependemos de Vexflow a la menor
  cantidad de fuentes posibles (con ese fin se creó `AdaptadorVexflow`)